### PR TITLE
notify subscribers to discard-items changes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+If you discover a security-related issue, please report it based on the instructions below.
+
+## Reporting a Vulnerability
+
+Please **DO NOT** file a public issue, instead report the vulnerability on the relevant
+[GitHub security](https://github.com/sysrepo/sysrepo/security) page. If you do not receive any reaction within 48 hours,
+please also send an email to [mvasko@cesnet.cz].
+
+## Review Process
+
+After receiving the report, an initial triage and technical analysis is performed to confirm the report and determine
+its scope. We may request additional information in this stage of the process.
+
+Once a reviewer has confirmed the relevance of the report, a draft security advisory will be created on GitHub. The
+draft advisory will be used to discuss the issue with maintainers, the reporter(s), and where applicable, other affected
+parties under embargo.
+
+If the vulnerability is accepted, a timeline for developing a patch, public disclosure, and patch release will be
+determined. If there is an embargo period on public disclosure before the patch release, the reporter(s) are expected to
+participate in the discussion of the timeline and abide by agreed upon dates for public disclosure.
+
+Usually, the reasonably complex issues are fixed within hours of being reported.
+
+## Supported Versions
+
+After an issue is fixed, it **WILL NOT** be backported to any released version. Instead, it is kept in the public `devel`
+branch, which is periodically merged into the main branch when a new release is due. So, the issue will be fixed in the
+next release after it is fixed.

--- a/src/common.c
+++ b/src/common.c
@@ -228,7 +228,7 @@ sr_ds_handle_init(struct sr_ds_handle_s **ds_handles, uint32_t *ds_handle_count)
     dir = opendir(plugins_dir);
     if (!dir) {
         if (errno != ENOENT) {
-            SR_ERRINFO_SYSERRNO(&err_info, "opendir");
+            sr_errinfo_new(&err_info, SR_ERR_SYS, "Opening dir \"%s\" failed (%s).", plugins_dir, strerror(errno));
         }
         goto cleanup;
     }
@@ -411,7 +411,7 @@ sr_ntf_handle_init(struct sr_ntf_handle_s **ntf_handles, uint32_t *ntf_handle_co
     dir = opendir(plugins_dir);
     if (!dir) {
         if (errno != ENOENT) {
-            SR_ERRINFO_SYSERRNO(&err_info, "opendir");
+            sr_errinfo_new(&err_info, SR_ERR_SYS, "Opening dir \"%s\" failed (%s).", plugins_dir, strerror(errno));
         }
         goto cleanup;
     }
@@ -1200,7 +1200,7 @@ sr_remove_evpipes(void)
 
     dir = opendir(sr_get_repo_path());
     if (!dir) {
-        SR_ERRINFO_SYSERRNO(&err_info, "opendir");
+        sr_errinfo_new(&err_info, SR_ERR_SYS, "Opening dir \"%s\" failed (%s).", sr_get_repo_path(), strerror(errno));
         goto cleanup;
     }
 
@@ -5470,7 +5470,7 @@ sr_conn_info(sr_cid_t **cids, pid_t **pids, uint32_t *count, sr_cid_t **dead_cid
             goto cleanup;
         }
 
-        sr_errinfo_new(&err_info, SR_ERR_SYS, "Opening directory \"%s\" failed (%s).", path, strerror(errno));
+        sr_errinfo_new(&err_info, SR_ERR_SYS, "Opening dir \"%s\" failed (%s).", path, strerror(errno));
         goto cleanup;
     }
 

--- a/src/edit_diff.c
+++ b/src/edit_diff.c
@@ -2398,7 +2398,8 @@ sr_oper_edit_mod_apply_data(const struct lyd_node *mod_first, struct ly_set *opa
     struct sr_oper_edit_arg arg = {0};
     const char *xpath;
     uint32_t i, j;
-    int found;
+    int found, keep;
+    struct lyd_attr *attr;
 
     assert((op == EDIT_MERGE) || (op == EDIT_REPLACE));
 
@@ -2508,21 +2509,30 @@ sr_oper_edit_mod_apply_data(const struct lyd_node *mod_first, struct ly_set *opa
     for (i = 0; i < opaq_set->count; ++i) {
         node = opaq_set->dnodes[i];
 
-        /* add the opaque node to data */
-        if ((err_info = sr_lyd_dup(node, NULL, LYD_DUP_NO_META, 0, &dup))) {
-            goto cleanup;
-        }
-        if ((err_info = sr_lyd_insert_sibling(*data, dup, data))) {
-            goto cleanup;
+        /* Persist only nodes with operation="none" as the second operation */
+        attr = ((struct lyd_node_opaq *)node)->attr;
+        attr = attr ? attr->next : NULL;
+        keep = attr && attr->value && !strcmp("none", attr->value);
+        if (keep) {
+            /* add the opaque node to data */
+            if ((err_info = sr_lyd_dup(node, NULL, LYD_DUP_NO_META, 0, &dup))) {
+                goto cleanup;
+            }
+            if ((err_info = sr_lyd_insert_sibling(*data, dup, data))) {
+                goto cleanup;
+            }
         }
 
         /* add the opaque node to diff */
         if ((err_info = sr_lyd_dup(node, NULL, LYD_DUP_NO_META, 0, &dup))) {
             goto cleanup;
         }
-        if ((err_info = sr_diff_set_oper(dup, "create"))) {
+
+        /* set create operation now only if persisting this, it will be added later by sr_modinfo_process_mod_discards */
+        if (keep && (err_info = sr_diff_set_oper(dup, "create"))) {
             goto cleanup;
         }
+
         if ((err_info = sr_lyd_insert_sibling(*mod_diff, dup, mod_diff))) {
             goto cleanup;
         }

--- a/src/modinfo.c
+++ b/src/modinfo.c
@@ -632,6 +632,107 @@ cleanup:
     return err_info;
 }
 
+/**
+ * @brief get the xpath if the node is a "/sysrepo:discard-items" node and refers to module_name
+ * NULL otherwise
+ * */
+static const char *
+sr_modinfo_mod_discard_xpath_get(struct lyd_node *node, const char *module_name)
+{
+    const struct lys_module *ly_mod;
+    const char *xpath = NULL;
+
+    if (node->schema) {
+        return NULL;
+    }
+
+    ly_mod = lyd_owner_module(node);
+    if (!ly_mod || strcmp(ly_mod->name, "sysrepo") || strcmp(LYD_NAME(node), "discard-items")) {
+        /* other opaque nodes */
+        return NULL;
+    }
+
+    xpath = lyd_get_value(node);
+    if (!xpath || !xpath[0]) {
+        /* invalid XPath */
+        return NULL;
+    }
+
+    if (!sr_xpath_refs_mod(xpath, module_name)) {
+        /* not interested in other modules at this time */
+        return NULL;
+    }
+
+    return xpath;
+}
+
+/**
+ * @brief
+ * For the given module_name, process "/sysrepo:discard-items" nodes
+ * 1. from mod_info->data -> remove the nodes matching discard xpath
+ * 2. to mod_info->diff add operation="delete" to nodes matching discard xpath
+ * 3. Remove discard-items nodes from mod_info->diff unless operation="create" was specified
+ * */
+static sr_error_info_t *
+sr_modinfo_process_mod_discards(struct sr_mod_info_s *mod_info, const char *module_name)
+{
+    sr_error_info_t *err_info = NULL;
+    struct lyd_node *next = NULL, *node = NULL;
+    struct ly_set *set = NULL;
+    uint32_t j;
+    const char *xpath = NULL;
+    struct lyd_meta *meta = NULL;
+    enum edit_op op;
+
+    LY_LIST_FOR_SAFE(mod_info->diff, next, node) {
+        xpath = sr_modinfo_mod_discard_xpath_get(node, module_name);
+        if (!xpath) {
+            /* skip irrelevant nodes */
+            continue;
+        }
+
+        if ((op = sr_edit_diff_find_oper(node, 0, NULL) == EDIT_DELETE)) {
+            /* discard-items is being deleted */
+            continue;
+        }
+
+        /* Step 1. from mod_info->data, remove all the discarded nodes */
+        if ((err_info = sr_lyd_xpath_complement(&mod_info->data, xpath))) {
+            return err_info;
+        }
+
+        /* Step 2. into mod_info->diff, add operation delete */
+
+        /* find the nodes matching the xpath from the diff */
+        if ((err_info = sr_lyd_find_xpath(mod_info->diff, xpath, &set))) {
+            return err_info;
+        }
+
+        /* get rid of all redundant results that are descendants of another result */
+        if ((err_info = sr_xpath_set_filter_subtrees(set))) {
+            return err_info;
+        }
+
+        /* Set meta to operation="delete" */
+        for (j = 0; j < set->count; ++j) {
+            meta = lyd_find_meta(set->dnodes[j]->meta, NULL, "yang:operation");
+            if (meta) {
+                lyd_change_meta(meta, "delete");
+            } else if ((err_info = sr_diff_set_oper(set->dnodes[j], "delete"))) {
+                return err_info;
+            }
+        }
+        ly_set_free(set, NULL);
+
+        /* Add a create now, if not previously added */
+        if ((EDIT_CREATE != op) && (err_info = sr_diff_set_oper(node, "create"))) {
+            return err_info;
+        }
+    }
+
+    return err_info;
+}
+
 sr_error_info_t *
 sr_modinfo_oper_edit_apply(struct sr_mod_info_s *mod_info, const struct lyd_node *data, int create_diff)
 {
@@ -674,6 +775,10 @@ sr_modinfo_oper_edit_apply(struct sr_mod_info_s *mod_info, const struct lyd_node
 
             /* merge the whole stored data and set 'none' operation (for filters using non-changed nodes to work) */
             if (create_diff && (err_info = sr_edit_mod_diff_merge(&mod_info->diff, mod->ly_mod, mod_info->data))) {
+                goto cleanup;
+            }
+
+            if ((err_info = sr_modinfo_process_mod_discards(mod_info, mod->ly_mod->name))) {
                 goto cleanup;
             }
         }

--- a/src/sysrepo.c
+++ b/src/sysrepo.c
@@ -3545,9 +3545,10 @@ sr_oper_delete_item_str(sr_session_ctx_t *session, const char *path, const char 
     return sr_delete_item(session, path, opts);
 }
 
-API int
-sr_discard_items(sr_session_ctx_t *session, const char *xpath)
+static int
+_sr_discard_items(sr_session_ctx_t *session, const char *xpath, int persist)
 {
+
     sr_error_info_t *err_info = NULL;
     struct lyd_node *node;
 
@@ -3571,8 +3572,15 @@ sr_discard_items(sr_session_ctx_t *session, const char *xpath)
     if ((err_info = sr_lyd_new_opaq(session->conn->ly_ctx, "discard-items", xpath, "sysrepo", "sysrepo", &node))) {
         goto cleanup;
     }
+
     if ((err_info = sr_edit_set_oper(node, "merge"))) {
         goto cleanup;
+    }
+    if (persist) {
+        /* add a "sysrepo:none" operation to persist this discard */
+        if ((err_info = sr_edit_set_oper(node, "none"))) {
+            goto cleanup;
+        }
     }
     if ((err_info = sr_lyd_insert_sibling(session->dt[session->ds].edit->tree, node, &session->dt[session->ds].edit->tree))) {
         lyd_free_tree(node);
@@ -3585,6 +3593,20 @@ cleanup:
         session->dt[session->ds].edit = NULL;
     }
     return sr_api_ret(session, err_info);
+}
+
+API int
+sr_discard_items(sr_session_ctx_t *session, const char *xpath)
+{
+    return _sr_discard_items(session, xpath, 1);
+}
+
+API int
+sr_session_discard_items(sr_session_ctx_t *session, const char *xpath)
+{
+    /* Should not be used when multiple sessions have pushed operational data to the same module */
+    /* will cause deletes to be informed to subscribers one-time, but the data will be present for subsequent reads */
+    return _sr_discard_items(session, xpath, 0);
 }
 
 API int

--- a/src/sysrepo.h
+++ b/src/sysrepo.h
@@ -982,6 +982,15 @@ int sr_oper_delete_item_str(sr_session_ctx_t *session, const char *path, const c
 int sr_discard_items(sr_session_ctx_t *session, const char *xpath);
 
 /**
+ * @brief Same as sr_session_discard_items, except the "discard-items" nodes are not persisted into the operational data SHM.
+ *
+ * When multiple sessions push data matching this xpath, a "delete" is published to the subscribers, but future reads will still see the data.
+ * So, use sr_discard_items instead.
+ *
+ * */
+int sr_session_discard_items(sr_session_ctx_t *session, const char *xpath);
+
+/**
  * @brief Prepare to move/create the instance of an user-ordered list or leaf-list to the specified position.
  * These changes are applied only after calling ::sr_apply_changes().
  *

--- a/tests/tcommon.c
+++ b/tests/tcommon.c
@@ -39,8 +39,8 @@ _test_log_msg(sr_log_level_t level, const char *message, const char *prefix)
         severity = "INF";
         break;
     case SR_LL_DBG:
-        /*severity = "DBG";
-        break;*/
+        severity = "DBG";
+        break;
         return;
     case SR_LL_NONE:
         assert(0);

--- a/tests/test_oper_push.c
+++ b/tests/test_oper_push.c
@@ -1905,6 +1905,30 @@ test_discard(void **state)
     free(str1);
 
     sr_session_stop(sess);
+
+    /* discard multiple nodes */
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/type",
+            "ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/speed",
+            "0", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/type",
+            "ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/speed",
+            "0", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_discard_items(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth1\']/speed");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_discard_items(st->sess, "/ietf-interfaces-new:interfaces/interface[name=\'eth2\']/speed");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
 }
 
 /* TEST */

--- a/tests/test_oper_push.c
+++ b/tests/test_oper_push.c
@@ -144,6 +144,7 @@ clear_up(void **state)
 {
     struct state *st = (struct state *)*state;
 
+    ATOMIC_STORE_RELAXED(st->cb_called, 0);
     sr_discard_oper_changes(NULL, st->sess, NULL, 0);
 
     sr_session_switch_ds(st->sess, SR_DS_STARTUP);
@@ -175,6 +176,200 @@ dummy_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_n
     (void)private_data;
 
     return SR_ERR_OK;
+}
+
+static int
+set_del_change_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *module_name, const char *xpath, sr_event_t event,
+        uint32_t request_id, void *private_data)
+{
+    struct state *st = (struct state *)private_data;
+
+    (void)session;
+    (void)sub_id;
+    (void)module_name;
+    (void)xpath;
+    (void)event;
+    (void)request_id;
+    char *str1 = NULL, *str2 = "";
+    const struct lyd_node *diff = sr_get_change_diff(session);
+    int ret;
+
+    ret = lyd_print_mem(&str1, diff, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    assert_int_equal(ret, 0);
+    switch (ATOMIC_INC_RELAXED(st->cb_called)) {
+    case 0:
+    case 1:
+    case 8:
+    case 9:
+        str2 = "<interfaces-state xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\" xmlns:or=\"urn:ietf:params:xml:ns:yang:ietf-origin\" or:origin=\"or:unknown\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"create\">\n"
+                "  <interface yang:key=\"\">\n"
+                "    <name>eth1</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "  <interface yang:key=\"[name='eth1']\">\n"
+                "    <name>eth2</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "</interfaces-state>\n";
+        assert_string_equal(str1, str2);
+        break;
+    case 2:
+    case 3:
+        str2 = "<interfaces-state xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">\n"
+                "  <interface yang:operation=\"create\" yang:key=\"[name='eth2']\">\n"
+                "    <name>eth3</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "  <interface yang:operation=\"none\">\n"
+                "    <name>eth1</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "  <interface yang:operation=\"delete\">\n"
+                "    <name>eth2</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "</interfaces-state>\n";
+        assert_string_equal(str1, str2);
+
+        break;
+
+    case 4:
+    case 5:
+        str2 = "<interfaces-state xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\" xmlns:or=\"urn:ietf:params:xml:ns:yang:ietf-origin\" or:origin=\"or:unknown\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">\n"
+                "  <interface>\n"
+                "    <name>eth1</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "  <interface yang:operation=\"delete\">\n"
+                "    <name>eth3</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "</interfaces-state>\n";
+        assert_string_equal(str1, str2);
+        break;
+
+    case 6:
+    case 7:
+        str2 = "<interfaces-state xmlns=\"urn:ietf:params:xml:ns:yang:ietf-interfaces\" xmlns:or=\"urn:ietf:params:xml:ns:yang:ietf-origin\" or:origin=\"or:unknown\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">\n"
+                "  <interface>\n"
+                "    <name>eth1</name>\n"
+                "    <type xmlns:ianaift=\"urn:ietf:params:xml:ns:yang:iana-if-type\">ianaift:ethernetCsmacd</type>\n"
+                "  </interface>\n"
+                "</interfaces-state>\n";
+        assert_string_equal(str1, str2);
+        break;
+    default:
+        /* called when not expected to be */
+        fail();
+    }
+    free(str1);
+    return SR_ERR_OK;
+}
+
+typedef int (*sr_discard_items_func)(sr_session_ctx_t *, const char *);
+
+static void
+test_oper_set_delete(void **state)
+{
+    struct state *st = (struct state *)*state;
+    sr_subscription_ctx_t *subscr = NULL;
+    int ret, i;
+    sr_data_t *data;
+    sr_discard_items_func discard_func[] = {sr_session_discard_items, sr_discard_items};
+
+    /* switch to operational DS */
+    ret = sr_session_switch_ds(st->sess, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* subscribe to operational data changes */
+    ret = sr_module_change_subscribe(st->sess, "ietf-interfaces", NULL,
+            set_del_change_cb, st, 0, 0, &subscr);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    for (i = 0; i < 2; i++) {
+        ATOMIC_STORE_RELAXED(st->cb_called, 0);
+        TLOG_INF("set eth1 and set eth2");
+        ret = sr_set_item_str(st->sess, "/ietf-interfaces:interfaces-state/interface[name='eth1']/type",
+                "iana-if-type:ethernetCsmacd", NULL, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+        ret = sr_set_item_str(st->sess, "/ietf-interfaces:interfaces-state/interface[name='eth2']/type",
+                "iana-if-type:ethernetCsmacd", NULL, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+        ret = sr_apply_changes(st->sess, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 2);
+
+        TLOG_INF("remove eth2 and set eth3");
+        const char *xpath_del = "/ietf-interfaces:interfaces-state/interface[name='eth2']";
+
+        ret = discard_func[i](st->sess, xpath_del);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        ret = sr_set_item_str(st->sess, "/ietf-interfaces:interfaces-state/interface[name='eth3']/type",
+                "iana-if-type:ethernetCsmacd", NULL, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        ret = sr_apply_changes(st->sess, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 4);
+
+        xpath_del = "/ietf-interfaces:interfaces-state/interface[name='eth3']";
+
+        TLOG_INF("only remove eth3");
+        ret = discard_func[i](st->sess, xpath_del);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        ret = sr_apply_changes(st->sess, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+
+        assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 6);
+        TLOG_INF("Discarding everything");
+        ret = sr_discard_oper_changes(NULL, st->sess, NULL, 0);
+        assert_int_equal(ret, SR_ERR_OK);
+        assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 8);
+    }
+
+    /* switch to running DS */
+    ret = sr_session_switch_ds(st->sess, SR_DS_RUNNING);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_set_item_str(st->sess, "/ietf-interfaces:interfaces/interface[name='eth0']/type",
+            "iana-if-type:ethernetCsmacd", NULL, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* subscribe to all configuration data just to enable them */
+    ret = sr_module_change_subscribe(st->sess, "ietf-interfaces", "/ietf-interfaces:interfaces/interface",
+            dummy_change_cb, NULL, 0, 0, &subscr);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* switch to operational DS */
+    ret = sr_session_switch_ds(st->sess, SR_DS_OPERATIONAL);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    ret = sr_session_discard_items(st->sess, "/ietf-interfaces:interfaces/interface");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* check that data still exists in operational datastore */
+    ret = sr_get_node(st->sess, "/ietf-interfaces:interfaces/interface[name='eth0']/type", 0, &data);
+    assert_int_equal(ret, SR_ERR_OK);
+    sr_release_data(data);
+
+    ret = sr_discard_items(st->sess, "/ietf-interfaces:interfaces/interface");
+    assert_int_equal(ret, SR_ERR_OK);
+    ret = sr_apply_changes(st->sess, 0);
+    assert_int_equal(ret, SR_ERR_OK);
+
+    /* check that no more callbacks have been called since */
+    assert_int_equal(ATOMIC_LOAD_RELAXED(st->cb_called), 8);
+
+    sr_unsubscribe(subscr);
+    subscr = NULL;
 }
 
 /* TEST */
@@ -2730,6 +2925,7 @@ int
 main(void)
 {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test_teardown(test_oper_set_delete, clear_up),
         cmocka_unit_test_teardown(test_conn_owner1, clear_up),
         cmocka_unit_test_teardown(test_conn_owner2, clear_up),
         cmocka_unit_test_teardown(test_conn_owner_same_data, clear_up),


### PR DESCRIPTION
Merge the "discard-items" nodes with data in the operational datastore. This will allow for subscribers to be notified when the data owner discards some data.

Do not persist sysrepo discard-items nodes into the SHM in all cases. When there is a single session pushing data into a module, there is no need to store all discard-items data into the SHM.

For certain types of data, such as a list with timestamp as the key, the application may keep pushing newer data, and discarding older data periodically.

In this case, the operational data SHM will grow unbounded, causing memory and CPU usage to increase over time.

While it is possible to manually edit the pushed operational changes with libyang API, it is not convenient, and makes migrating to sysrepo version 3.x painful.

A new API is defined sr_session_discard_items(), which operates just like sr_discard_items but does not store the discard-items nodes in the SHM, and has 2 limitations
1. This only affects pushed changes of this session and no other sessions.
2. This cannot be used to affect enabled data (running datastore data copied due to an active subscription)